### PR TITLE
Fix vendor URL

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
   <id>com.github.pixel365.goverage</id>
   <name>Goverage</name>
-  <vendor url="https://github.com/pisel365">pixel365</vendor>
+  <vendor url="https://github.com/pixel365">pixel365</vendor>
 
   <description><![CDATA[
     Goverage is a JetBrains plugin for GoLand that shows inline test coverage percentages for each function,


### PR DESCRIPTION
## Summary
- update vendor URL to pixel365

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_686e7ffdfefc832291b3b56e26c510bb