### PR TITLE
Fix coverage hint range check

### DIFF
--- a/src/main/kotlin/com/github/pixel365/goverage/GoverageInlayHintsProvider.kt
+++ b/src/main/kotlin/com/github/pixel365/goverage/GoverageInlayHintsProvider.kt
@@ -40,7 +40,8 @@ class GoverageInlayHintsProvider : InlayHintsProvider<NoSettings> {
                     var total = 0
 
                     for (entry in coverageEntries) {
-                        if (entry.startLine in startLine..endLine || entry.endLine in startLine..endLine) {
+                        // Count entries that intersect with the function range
+                        if (entry.startLine <= endLine && entry.endLine >= startLine) {
                             total += entry.statements
                             if (entry.count > 0) {
                                 covered += entry.statements

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
   <id>com.github.pixel365.goverage</id>
   <name>Goverage</name>
-  <vendor url="https://github.com/pisel365">pixel365</vendor>
+  <vendor url="https://github.com/pixel365">pixel365</vendor>
 
   <description><![CDATA[
     Goverage is a JetBrains plugin for GoLand that shows inline test coverage percentages for each function,


### PR DESCRIPTION
## Summary
- fix intersection logic for coverage hints in `GoverageInlayHintsProvider`
- correct vendor URL in plugin metadata

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_686e7eae582083228d546cd9d12a02c6