### PR TITLE
Fix cache update for coverage entries

### DIFF
--- a/src/main/kotlin/com/github/pixel365/goverage/CoverageCache.kt
+++ b/src/main/kotlin/com/github/pixel365/goverage/CoverageCache.kt
@@ -49,7 +49,7 @@ object CoverageCache {
         if (!coverageFile.exists()) return null
 
         if (coverageFile.lastModified() > lastModified) {
-            parseCoverageFile(coverageFile)
+            coverageMap = parseCoverageFile(coverageFile)
             lastModified = coverageFile.lastModified()
         }
 


### PR DESCRIPTION
## Summary
- keep coverage map up-to-date in `getCoverageEntriesForFile`

## Testing
- `./gradlew test` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686e82166fb083228da9b49662d2cf0e